### PR TITLE
pattern for URL validation was fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Implement the ability to add custom validation callback to the `TextField`.
 Check if `imgUrl` and `imdbUrl` are valid URLs (you can use the next regex)
 
 ```js
-const pattern = /^((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=+$,\w]+@)?[A-Za-z0-9.-]+|(?:www\.|[-;:&=+$,\w]+@)[A-Za-z0-9.-]+)((?:\/[+~%/.\w-_]*)?\??(?:[-+=&;%@.\w_]*)#?(?:[.!/\\\w]*))?)$/;
+const pattern = /^((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=+$,\w]+@)?[A-Za-z0-9.-]+|(?:www\.|[-;:&=+$,\w]+@)[A-Za-z0-9.-]+)((?:\/[+~%/.\w-_]*)?\??(?:[-+=&;%@,.\w_]*)#?(?:[,.!/\\\w]*))?)$/;
 ```
 
 ## Instructions


### PR DESCRIPTION
Added a missing comma in the given regex in readme file. Without this comma tests do not pass.